### PR TITLE
send host header with the GET request

### DIFF
--- a/dockermon.py
+++ b/dockermon.py
@@ -56,14 +56,16 @@ def connect(url):
     if url.scheme == 'tcp':
         sock = socket()
         netloc = tuple(url.netloc.rsplit(':', 1))
+        hostname = socket.gethostname()
     elif url.scheme == 'ipc':
         sock = socket(AF_UNIX)
         netloc = url.path
+        hostname = 'localhost'
     else:
         raise ValueError('unknown socket type: %s' % url.scheme)
 
     sock.connect(netloc)
-    return sock
+    return sock, hostname
 
 
 def watch(callback, url=default_sock_url):
@@ -71,10 +73,10 @@ def watch(callback, url=default_sock_url):
 
         url can be either tcp://<host>:port or ipc://<path>
     """
-    sock = connect(url)
+    sock, hostname = connect(url)
 
     with closing(sock):
-        sock.sendall(b'GET /events HTTP/1.1\nHost: foo\n\n')
+        sock.sendall(b'GET /events HTTP/1.1\nHost: ' + hostname + '\n\n')
         header, payload = read_http_header(sock)
         status, reason = header_status(header)
         if status != HTTP_OK:

--- a/dockermon.py
+++ b/dockermon.py
@@ -74,7 +74,7 @@ def watch(callback, url=default_sock_url):
     sock = connect(url)
 
     with closing(sock):
-        sock.sendall(b'GET /events HTTP/1.1\n\n')
+        sock.sendall(b'GET /events HTTP/1.1\nHost: foo\n\n')
         header, payload = read_http_header(sock)
         status, reason = header_status(header)
         if status != HTTP_OK:


### PR DESCRIPTION
Changes in golang 1.6 don't allow http requests with a null host header.

This causes 

```
HTTP/1.1 400 Bad Request
Content-Type: text/plain
Connection: close

400 Bad Request: missing required Host header
Traceback (most recent call last):
  File "./dockermon.py", line 146, in <module>
    watch(callback, args.socket_url)
  File "./dockermon.py", line 82, in watch
    raise DockermonError('bad HTTP status: %s %s' % (status, reason))
__main__.DockermonError: bad HTTP status: 400 Bad Request
```

To fix this we just need to include some host header. The fix was taken from [here](https://github.com/golang/go/commit/6e11f45ebdbc7b0ee1367c80ea0a0c0ec52d6db5#diff-efeb3eb1778365f33e31e5ce03e746e9R2937)

see these links for more info.
https://github.com/golang/go/issues/15276
https://github.com/golang/go/issues/13624
